### PR TITLE
feat(validate-drm): KRON-430

### DIFF
--- a/docs/drm/Validate.yaml
+++ b/docs/drm/Validate.yaml
@@ -1,0 +1,108 @@
+x-stoplight:
+  docs:
+    showModels: false
+openapi: 3.0.3
+info:
+  title: MediaPlatform DRM API Specification
+  description: |
+    The following API Specification outlines the entry access to the MediaPlatform application.
+
+    The resources within this document provide examples of requests and responses to help development teams with DRM Integration.
+  version: 1.0.0
+  contact:
+    name: StreamAMG
+paths:
+  /api/v1/validatedrm/{entryId}/{customerId}:
+    get:
+      summary: Validate customer access to the entry
+      parameters:
+        - in: path
+          name: entryId
+          schema:
+            type: string
+          required: true
+          description: The entry id
+        - in: path
+          name: customerId
+          schema:
+            type: string
+          required: true
+          description: The customer id  
+      responses:
+        '200':
+          description: |-
+            Validation request responses
+          content:
+            application/json:
+              schema:
+                description: ''
+                type: object
+                x-examples:
+                  example-1:
+                    Granted: false
+                    Reason: Invalid customer id
+                properties:
+                  Granted:
+                    type: boolean
+                  Reason:
+                    type: string
+                    nullable: true       
+                required:
+                  - Granted
+              examples:
+                Customer account is granted:
+                  value:
+                    Granted: true     
+                Customer account is blocked:
+                  value:
+                    Granted: false
+                    Reason: Account blocked  
+                Customer account don't have an active session:
+                  value:
+                    Granted: false
+                    Reason: No active session
+                Customer account don't have valid entitlements:
+                  value:
+                    Granted: false
+                    Reason: No entitlement
+                Customer account don't have valid subscription:
+                  value:
+                    Granted: false
+                    Reason: No subscription
+                Unknown reason, includes CardAuthenticationRequired but doesn't include ConcurrencyCheck:
+                  value:
+                    Granted: false
+                    Reason: Unknown reason    
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                description: ''
+                type: object
+                properties:
+                  Granted: 
+                    type: boolean
+                  Reason:
+                    type: string
+                required:
+                  - Granted
+                  - Reason
+                x-examples:
+                  example-1:
+                    Granted: false
+                    Reason: Unknown reason
+              examples:
+                Unknown reason:
+                  value:
+                    Granted: false
+                    Reason: Unknown reason
+      description: |-
+        In order to validate that a customer has an access to the media entry.
+
+        A customer should have a valid session (Freemium and Premium) and a correct paid subscription (entitlements) for Premium content.
+
+      operationId: validate-drm
+    parameters: []
+servers:
+  - url: 'https://payments.streamamg.com'    

--- a/toc.json
+++ b/toc.json
@@ -40,6 +40,15 @@
 				"title": "Java",
 				"uri": "docs/sdk/Java.md"
 			}]
+		},
+		{
+			"type": "group",
+			"title": "DRM",
+			"items": [{
+				"type": "item",
+				"title": "Validate an entry for a customer",
+				"uri": "docs/drm/validatedrm.yaml"
+			}]
 		}
 	]
 }


### PR DESCRIPTION
Adding /api/v1/validatedrm/{entryId}/{customerId}
To discuss about server domain - payments or other
To discuss about that Granted: false to be with status 200 too.
To discuss about a different response because current respose cover existed endpoint but we can change always
e.g. {
Granted: false,
Reason: No Entitlements
}